### PR TITLE
add invoke chain enhancement：dubbo full payload refinement

### DIFF
--- a/com.creditease.uav.console/src/main/webapp/uavapp_godeye/appmonitor/js/uav.apm.js
+++ b/com.creditease.uav.console/src/main/webapp/uavapp_godeye/appmonitor/js/uav.apm.js
@@ -719,7 +719,7 @@ function APMTool(app) {
 			var errMsg = "数据处理中，请刷新重试";
 			var epinfo = sObj["epinfo"].split(",")[0];
 			//当前支持的类型
-			var epinfos = ["http.service","apache.http.Client","apache.http.AsyncClient","mq.service","rabbitmq.client","jdbc.client","method"];
+			var epinfos = ["http.service","apache.http.Client","apache.http.AsyncClient","mq.service","rabbitmq.client","jdbc.client","method","dubbo.provider","dubbo.consumer"];
 			if($.inArray(epinfo, epinfos)==-1){
 				errMsg = "不支持的数据类型，努力更新中...";
 			}

--- a/com.creditease.uav.hook.dubbo/src/main/java/com/creditease/uav/hook/dubbo/DubboHookProxy.java
+++ b/com.creditease.uav.hook.dubbo/src/main/java/com/creditease/uav/hook/dubbo/DubboHookProxy.java
@@ -112,9 +112,10 @@ public class DubboHookProxy extends HookProxy {
                         if ("invoke".equals(m.getName())) {
 
                             dpInstall.defineLocalVal(m, "mObj", DubboIT.class);
-                            m.insertBefore("{DubboIT.doMonitorStart(\"" + appid + "\",new Object[]{$1,$2},false,null);}");
-                            m.insertAfter("{DubboIT.doMonitorEnd(new Object[]{$1,$2},true,null);}");
-                            dpInstall.addCatch(m,"{DubboIT.doMonitorEnd(new Object[]{$1,$2},true,$e);throw $e;}");
+                            m.insertBefore(
+                                    "{DubboIT.doMonitorStart(\"" + appid + "\",new Object[]{$1,$2},false,null);}");
+                            m.insertAfter("{DubboIT.doMonitorEnd(new Object[]{$1,$2,$_},true,null);}");
+                            dpInstall.addCatch(m, "{DubboIT.doMonitorEnd(new Object[]{$1,$2},true,$e);throw $e;}");
 
                         }
                     }

--- a/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/invokechain/collect/SlowOperDataCollectHandler.java
+++ b/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/invokechain/collect/SlowOperDataCollectHandler.java
@@ -67,6 +67,8 @@ public class SlowOperDataCollectHandler extends AbstractCollectDataHandler {
         new SlowOperMQProducerAction("rabbitmq.client", feature, engine);
         new SlowOperMethodAction("method", feature, engine);
         new SlowOperJdbcAction("jdbc.client", feature, engine);
+        new SlowOperMethodAction("dubbo.provider", feature, engine, "dubbo");
+        new SlowOperMethodAction("dubbo.consumer", feature, engine, "dubbo");
     }
 
     @Override

--- a/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/invokechain/collect/actions/SlowOperMethodAction.java
+++ b/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/invokechain/collect/actions/SlowOperMethodAction.java
@@ -33,8 +33,15 @@ import com.creditease.uav.invokechain.data.MethodSlowOperSpan;
  */
 public class SlowOperMethodAction extends AbstractSlowOperProtocolAction {
 
+    private String protocolType = "method";
+
     public SlowOperMethodAction(String cName, String feature, IActionEngine engine) {
         super(cName, feature, engine);
+    }
+
+    public SlowOperMethodAction(String cName, String feature, IActionEngine engine, String protocolType) {
+        super(cName, feature, engine);
+        this.protocolType = protocolType;
     }
 
     @Override
@@ -80,7 +87,7 @@ public class SlowOperMethodAction extends AbstractSlowOperProtocolAction {
     @Override
     public String getProtocolType() {
 
-        return "method";
+        return this.protocolType;
     }
 
 }

--- a/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/invokechain/data/Span.java
+++ b/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/invokechain/data/Span.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.creditease.agent.helpers.DataConvertHelper;
+import com.creditease.agent.helpers.EncodeHelper;
 import com.creditease.agent.helpers.StringHelper;
 
 public class Span {
@@ -113,7 +114,7 @@ public class Span {
         this.className = info[9];
         this.methodName = info[10];
         this.url = info[11];
-        this.state = info[12];
+        this.state = EncodeHelper.urlDecode(info[12]);
 
     }
 

--- a/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/invokechain/http/SlowOperQueryHandler.java
+++ b/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/invokechain/http/SlowOperQueryHandler.java
@@ -66,11 +66,14 @@ public class SlowOperQueryHandler extends AbstractHttpHandler<UAVHttpMessage> {
         typeMap.put("rabbitmq.client", "mq");
         typeMap.put("jdbc.client", "jdbc");
         typeMap.put("method", "method");
+        typeMap.put("dubbo.provider", "dubbo");
+        typeMap.put("dubbo.consumer", "dubbo");
 
         typeBodyMap.put("rpc", new String[] { "rpc_req_body", "rpc_rsp_body", "rpc_rsp_exception" });
         typeBodyMap.put("mq", new String[] { "mq_body" });
         typeBodyMap.put("method", new String[] { "method_req", "method_ret" });
         typeBodyMap.put("jdbc", new String[] { "sql_req", "sql_ret" });
+        typeBodyMap.put("dubbo", new String[] { "method_req", "method_ret" });
     }
 
     public SlowOperQueryHandler(String cName, String feature) {

--- a/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/invokechain/span/Span.java
+++ b/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/invokechain/span/Span.java
@@ -22,6 +22,7 @@ package com.creditease.uav.apm.invokechain.span;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.creditease.agent.helpers.EncodeHelper;
 import com.creditease.agent.helpers.StringHelper;
 
 public class Span implements Cloneable {
@@ -227,6 +228,7 @@ public class Span implements Cloneable {
         else {
             this.state = rc + "?" + state;
         }
+        this.state = EncodeHelper.urlEncode(this.state);
     }
 
     @Override

--- a/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/slowoper/handlers/MethodSlowOperHandler.java
+++ b/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/slowoper/handlers/MethodSlowOperHandler.java
@@ -20,7 +20,6 @@
 
 package com.creditease.uav.apm.slowoper.handlers;
 
-import com.creditease.agent.helpers.DataConvertHelper;
 import com.creditease.uav.apm.slowoper.span.SlowOperSpan;
 import com.creditease.uav.apm.slowoper.spi.SlowOperConstants;
 import com.creditease.uav.apm.slowoper.spi.SlowOperContext;
@@ -37,28 +36,10 @@ public class MethodSlowOperHandler extends AbstractSlowOperHandler {
 
         if (slowOperContext.containsKey(SlowOperConstants.PROTOCOL_METHOD_PARAMS)) {
             String methodParams = (String) slowOperContext.get(SlowOperConstants.PROTOCOL_METHOD_PARAMS);
-            // 限定采集的协议体的大小 当length为小于0时不限制长度，为0时则直接为空（不去获取）
-            int methodParamsLength = DataConvertHelper.toInt(System.getProperty("com.creditease.uav.ivcdat.method.req"),
-                    2000);
-            if (methodParams.length() > methodParamsLength && methodParamsLength > 0) {
-                methodParams = methodParams.substring(0, methodParamsLength);
-            }
-            else if (methodParamsLength == 0) {
-                methodParams = "";
-            }
             slowOperSpan.appendContent(";" + methodParams);
         }
         else {
             String methodReturn = (String) slowOperContext.get(SlowOperConstants.PROTOCOL_METHOD_RETURN);
-            // 限定采集的协议体的大小 当length为小于0时不限制长度，为0时则直接为空（不去获取）
-            int methodReturnLength = DataConvertHelper.toInt(System.getProperty("com.creditease.uav.ivcdat.method.ret"),
-                    2000);
-            if (methodReturn.length() > methodReturnLength && methodReturnLength > 0) {
-                methodReturn = methodReturn.substring(0, methodReturnLength);
-            }
-            else if (methodReturnLength == 0) {
-                methodReturn = "";
-            }
             slowOperSpan.appendContent(";o;" + methodReturn.length() + ";" + methodReturn);
         }
     }

--- a/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/slowoper/spi/SlowOperConstants.java
+++ b/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/slowoper/spi/SlowOperConstants.java
@@ -38,6 +38,8 @@ public class SlowOperConstants {
     public static final String SLOW_OPER_MQ_RABBIT_PRODUCER = "rabbitmq.client";
     public static final String SLOW_OPER_JDBC_CLIENT = "jdbc.client";
     public static final String SLOW_OPER_METHOD = "method";
+    public static final String SLOW_OPER_DUBBO_CONSUMER = "dubbo.consumer";
+    public static final String SLOW_OPER_DUBBO_PROVIDER = "dubbo.provider";
 
     // 重调用链处理各种协议关键字
     public static final String PROTOCOL_HTTP_HEADER = "protocol.http.header";

--- a/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/supporters/SlowOperSupporter.java
+++ b/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/supporters/SlowOperSupporter.java
@@ -78,6 +78,12 @@ public class SlowOperSupporter extends Supporter {
 
         // register 处理method类型的handler
         handlerMap.put(SlowOperConstants.SLOW_OPER_METHOD, new MethodSlowOperHandler());
+
+        // register 处理dubbo consumer类型的handler
+        handlerMap.put(SlowOperConstants.SLOW_OPER_DUBBO_CONSUMER, new MethodSlowOperHandler());
+
+        // register 处理dubbo provider类型的handler
+        handlerMap.put(SlowOperConstants.SLOW_OPER_DUBBO_PROVIDER, new MethodSlowOperHandler());
     }
 
     @Override

--- a/com.creditease.uav.monitorframework.buildFat/src/main/java/com/creditease/monitorframework/fat/TestRestService.java
+++ b/com.creditease.uav.monitorframework.buildFat/src/main/java/com/creditease/monitorframework/fat/TestRestService.java
@@ -449,7 +449,7 @@ public class TestRestService {
         ConnectionFactory factory = new ConnectionFactory();
         factory.setUsername("guest");
         factory.setPassword("guest");
-        factory.setHost("127.0.0.1");
+        factory.setHost("10.100.66.81");
         factory.setPort(5672);
         try {
             com.rabbitmq.client.Connection conn = factory.newConnection();
@@ -495,7 +495,7 @@ public class TestRestService {
     public void testRocketmq(String jsonString) {
 
         DefaultMQProducer producer = new DefaultMQProducer("hookTest");
-        producer.setNamesrvAddr("127.0.0.1:9876");
+        producer.setNamesrvAddr("10.100.33.135:9876");
         Message msg = new Message("SELF_TEST_TOPIC", "test".getBytes());
         try {
             producer.start();
@@ -517,7 +517,7 @@ public class TestRestService {
             e.printStackTrace();
         }
         DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer("hookTest");
-        pushConsumer.setNamesrvAddr("127.0.0.1:9876");
+        pushConsumer.setNamesrvAddr("10.100.33.135:9876");
         pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_FIRST_OFFSET);
         pushConsumer.registerMessageListener(new MessageListenerOrderly() {
 
@@ -568,6 +568,28 @@ public class TestRestService {
         IMyDubboService mds = (IMyDubboService) wac.getBean("myDubboServiceC");
 
         return mds.sayHello("zz");
+    }
+
+    @POST
+    @Path("testDubboExceptin")
+    public String testDubboExceptin() throws IOException {
+
+        WebApplicationContext wac = WebApplicationContextUtils.getWebApplicationContext(sc);
+
+        IMyDubboService mds = (IMyDubboService) wac.getBean("myDubboServiceC");
+
+        return mds.sayException("exception");
+    }
+
+    @POST
+    @Path("testDubboUncatchException")
+    public String testDubboUncatchException() {
+
+        WebApplicationContext wac = WebApplicationContextUtils.getWebApplicationContext(sc);
+
+        IMyDubboService mds = (IMyDubboService) wac.getBean("myDubboServiceC");
+
+        return mds.sayUncatchException("UncatchException");
     }
 
     DAOFactory factory;

--- a/com.creditease.uav.monitorframework.buildFat/src/main/java/com/creditease/monitorframework/fat/dubbo/IMyDubboService.java
+++ b/com.creditease.uav.monitorframework.buildFat/src/main/java/com/creditease/monitorframework/fat/dubbo/IMyDubboService.java
@@ -20,8 +20,13 @@
 
 package com.creditease.monitorframework.fat.dubbo;
 
+import java.io.IOException;
 
 public interface IMyDubboService {
 
     String sayHello(String name);
+
+    String sayException(String name) throws IOException;
+
+    String sayUncatchException(String name);
 }

--- a/com.creditease.uav.monitorframework.buildFat/src/main/java/com/creditease/monitorframework/fat/dubbo/MyDubboService.java
+++ b/com.creditease.uav.monitorframework.buildFat/src/main/java/com/creditease/monitorframework/fat/dubbo/MyDubboService.java
@@ -20,6 +20,7 @@
 
 package com.creditease.monitorframework.fat.dubbo;
 
+import java.io.IOException;
 
 public class MyDubboService implements IMyDubboService {
 
@@ -28,6 +29,20 @@ public class MyDubboService implements IMyDubboService {
 
         // TODO Auto-generated method stub
         return name;
+    }
+
+    @Override
+    public String sayException(String name) throws IOException {
+
+        throw new IOException("专门测试用的异常");
+    }
+
+    @Override
+    public String sayUncatchException(String name) {
+
+        String exceptionInt = "test";
+        int num = Integer.parseInt(exceptionInt);
+        return name + num;
     }
 
 }


### PR DESCRIPTION
1，通过添加dubbo（Result）劫持点，捕获dubbo远程调用的返回数据和异常

    1）对应IT位置增添Result参数；

    2）添加获取Result中异常处理（以原异常为主，Result异常只有在原异常为null才记录）。

2，添加对应dubbo的adapter

    1）虽然dubbo属于rpc，但其使用方式与method相同，故当前采用UAV的method协议方式记录。

3，HM中添加对应处理逻辑；

4，HM中添加对应查询逻辑；

5，前端展示添加对于dubbo的支持；