### PR TITLE
Fix Issues #41 the MSCP node has no version information after the upgrade

### DIFF
--- a/com.creditease.uav.agent.heartbeat/src/main/java/com/creditease/agent/feature/hbagent/handlers/HBClientDefaultHandler.java
+++ b/com.creditease.uav.agent.heartbeat/src/main/java/com/creditease/agent/feature/hbagent/handlers/HBClientDefaultHandler.java
@@ -294,6 +294,9 @@ public class HBClientDefaultHandler extends AbstractHBClientHandler {
             Map<String, Map<String, String>> resultMap = new HashMap<String, Map<String, String>>();
             for (int i = 0; i < roots.length; i++) {
                 File file = roots[i];
+                if (0 == file.getTotalSpace())
+                    continue;
+
                 Map<String, String> temp = new HashMap<String, String>();
                 temp.put("free", String.valueOf(Math.round((double) (file.getFreeSpace() / 1024))));
                 temp.put("total", String.valueOf(Math.round((double) (file.getTotalSpace() / 1024))));

--- a/com.creditease.uav.agent.heartbeat/src/main/java/com/creditease/agent/feature/procdetectagent/OSProcessScanner.java
+++ b/com.creditease.uav.agent.heartbeat/src/main/java/com/creditease/agent/feature/procdetectagent/OSProcessScanner.java
@@ -312,7 +312,7 @@ public class OSProcessScanner extends AbstractTimerWork {
                     proc.addPort(port);
 
                     portList = portList.append(port).append(" ");
-                    if (!"UNKOWN".equals(proc.getName())) {
+                    if (!"UNKNOWN".equals(proc.getName())) {
                         continue;
                     }
 

--- a/com.creditease.uav.console/src/main/webapp/uavapp_godeye/uavnetwork/js/uav.network.js
+++ b/com.creditease.uav.console/src/main/webapp/uavapp_godeye/uavnetwork/js/uav.network.js
@@ -1144,6 +1144,7 @@ var mvcObj={
             "node.pid":"info/node.pid",
             "node.procs":"info/node.procs",
             "node.services":"info/node.services",
+            "node.version":"info/node.version",
             "node.docker.info": "info/node.docker.info",
             "node.docker.container": "info/node.docker.container"
         }

--- a/com.creditease.uav.helper/src/main/java/com/creditease/agent/helpers/osproc/OSProcess.java
+++ b/com.creditease.uav.helper/src/main/java/com/creditease/agent/helpers/osproc/OSProcess.java
@@ -34,7 +34,7 @@ public class OSProcess {
     private Set<String> ports = new HashSet<String>();
 
     // program name
-    private String name = "UNKOWN";
+    private String name = "UNKNOWN";
 
     // extract info to describe the process
     private Map<String, String> tags = new LinkedHashMap<String, String>();


### PR DESCRIPTION
https://github.com/uavorg/uavstack/issues/41
1.Fix Issues #41 the MSCP node has no version information after the
upgrade.
2.Changed the default name of OSProcess from "UNKOWN" to "UNKNOWN".
3.Filter the empty disk information.