### PR TITLE
The system variables in "system.cache" can not be used when MSCP reboot

### DIFF
--- a/com.creditease.uav.monitorframework/src/main/java/com/creditease/monitor/UAVMetaDataMgr.java
+++ b/com.creditease.uav.monitorframework/src/main/java/com/creditease/monitor/UAVMetaDataMgr.java
@@ -174,7 +174,14 @@ public class UAVMetaDataMgr {
         for (String key : SystemMeta) {
 
             if (metaData.containsKey(key)) {
-                System.setProperty(key, (String) metaData.get(key));
+            	
+            	String value = System.getProperty(key);
+            	
+            	if (StringHelper.isEmpty(value)) {
+            		System.setProperty(key, (String) metaData.get(key));
+               }
+             
+            
             }
         }
         if (log.isLogEnabled()) {

--- a/com.creditease.uav.monitorframework/src/main/java/com/creditease/monitor/UAVMetaDataMgr.java
+++ b/com.creditease.uav.monitorframework/src/main/java/com/creditease/monitor/UAVMetaDataMgr.java
@@ -174,14 +174,13 @@ public class UAVMetaDataMgr {
         for (String key : SystemMeta) {
 
             if (metaData.containsKey(key)) {
-            	
-            	String value = System.getProperty(key);
-            	
-            	if (StringHelper.isEmpty(value)) {
-            		System.setProperty(key, (String) metaData.get(key));
-               }
-             
-            
+
+                String value = System.getProperty(key);
+
+                if (StringHelper.isEmpty(value)) {
+                    System.setProperty(key, (String) metaData.get(key));
+                }
+
             }
         }
         if (log.isLogEnabled()) {


### PR DESCRIPTION
https://github.com/uavorg/uavstack/issues/51
The system variables in "system.cache" can not be used when MSCP reboot
MSCP重启后无法正确使用system.cache的系统变量