### PR TITLE
Apphub user behavior record add info & fix Apphub ajax assembly params not default

### DIFF
--- a/com.creditease.uav.console/src/main/java/com/creditease/uav/apphub/filter/SessionAsyncFilter.java
+++ b/com.creditease.uav.console/src/main/java/com/creditease/uav/apphub/filter/SessionAsyncFilter.java
@@ -263,7 +263,11 @@ public class SessionAsyncFilter implements Filter {
         userInfo.put("type", actiontype);
         userInfo.put("url", actionurl);
         userInfo.put("desc", actiondesc);
-
+        userInfo.put("authemails", String
+                .valueOf(request.getSession(false).getAttribute("apphub.gui.session.login.user.authorize.emailList")));
+        userInfo.put("authsystems", String
+                .valueOf(request.getSession(false).getAttribute("apphub.gui.session.login.user.authorize.systems")));
+        
         logger.info(this, JSONHelper.toString(userInfo));
     }
 

--- a/com.creditease.uav.console/src/main/webapp/apphub/js/common/helper.js
+++ b/com.creditease.uav.console/src/main/webapp/apphub/js/common/helper.js
@@ -639,7 +639,7 @@ var AjaxHelper={
 			cache:cfg.cache,
 			data:cfg.data,
 			dataType:cfg.dataType,
-			contentType:cfg.contentType,
+			contentType:(typeof(value)=="undefined"?"application/json; charset=UTF-8":cfg.contentType),
 			beforeSend:function () {
 				timeOutId = setTimeout(function(){PageHelper.showLoading();},1000);
 		    },


### PR DESCRIPTION
----Apphub user behavior record add info---
我们需要一份匹配用户信息，在Apphub授权的邮箱组列表
1、在用户登录授权时：丰富用户session字段\内容：用户匹配的被授权的邮箱组和系统列表
2、用户行为日志（ulog）丰富字段、JS用户变量（前端同样可以获取登录用户数据）丰富字段

----- fix Apphub ajax assembly params not default----
1、apphub ajax contentType 添加默认类型：application/json; charset=UTF-8
2、原因描述：开启重调用链后，mof会对rs接口进行拦截处理，对没有定义上传参数的ajax提交请求，会使用默认处理。从而导致与rs接口不匹配，最终报错。