### PR TITLE
When the application is named ROOT, the corresponding URL cannot be found and the log cannot be linked 

### DIFF
--- a/com.creditease.uav.console/src/main/webapp/uavapp_godeye/appmonitor/js/uav.apm.js
+++ b/com.creditease.uav.console/src/main/webapp/uavapp_godeye/appmonitor/js/uav.apm.js
@@ -301,6 +301,9 @@ function APMTool(app) {
 		params.ipport = pNode.getElementsByTagName("td")[7].id;
 		params.appid = pNode.getElementsByTagName("td")[8].id;
 		var appurl = "http://"+params.ipport+"/"+params.appid+"/";
+		if(params.appid=="ROOT"){
+			appurl = "http://"+params.ipport+"/";
+		}
 		AjaxHelper.call({
             url: '../../rs/godeye/profile/q/cache',
             data: {"fkey":"appurl","fvalue":appurl},


### PR DESCRIPTION
https://github.com/uavorg/uavstack/issues/122
在webapps下 如果应用名即为ROOT.war,找不到对应的url;不需要再加ROOT