### PR TITLE
Fix Log profile with redundant ‘/’ caused logs can‘t be collected && Type conversion error when the form of Container port is ip:port 

### DIFF
--- a/com.creditease.uav.agent/src/main/java/com/creditease/agent/feature/logagent/RuleFilterFactory.java
+++ b/com.creditease.uav.agent/src/main/java/com/creditease/agent/feature/logagent/RuleFilterFactory.java
@@ -376,6 +376,7 @@ public class RuleFilterFactory {
 
     public void pubLogFilterAndRule(String id, LogFilterAndRule lfar) {
 
+        // 保证路径不存在多余的'/'等
         id = new File(id).getAbsolutePath();
 
         logcollection.put(id, lfar);

--- a/com.creditease.uav.agent/src/main/java/com/creditease/agent/feature/logagent/RuleFilterFactory.java
+++ b/com.creditease.uav.agent/src/main/java/com/creditease/agent/feature/logagent/RuleFilterFactory.java
@@ -20,6 +20,7 @@
 
 package com.creditease.agent.feature.logagent;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -374,6 +375,8 @@ public class RuleFilterFactory {
     }
 
     public void pubLogFilterAndRule(String id, LogFilterAndRule lfar) {
+
+        id = new File(id).getAbsolutePath();
 
         logcollection.put(id, lfar);
     }

--- a/com.creditease.uav.healthmanager/src/main/java/com/creditease/uav/feature/runtimenotify/scheduler/NodeInfoWatcher.java
+++ b/com.creditease.uav.healthmanager/src/main/java/com/creditease/uav/feature/runtimenotify/scheduler/NodeInfoWatcher.java
@@ -643,7 +643,7 @@ public class NodeInfoWatcher extends AbstractTimerWork {
             Map<String, Object> dv = (Map<String, Object>) disk.get(dk);
             for (String dvk : dv.keySet()) {
                 String dvv = dv.get(dvk).toString();
-                if ("useRate".equals(dvk) || "useRateInode".equals(dvk)) {
+                if ("useRate".equals(dvk)) {
                     dvv = dvv.replace("%", ""); // cut '%'
                 }
                 infoMap.put("os.io.disk" + pk + dvk, dvv);


### PR DESCRIPTION
1.日志画像中画像的路径存在多余'/'时，无法匹配正确的日志过滤规则。
例如：日志画像为/app/apollo/tomcat/logs//service/apollo-service-2017-12-26.log，但匹配时所用的key为/app/apollo/tomcat/logs/service/apollo-service-2017-12-26.log。
修改：过滤日志规则中多余的'/'等，使二者匹配。
2.container的采集的端口形式为ip:port，不是通常的port，在将其转为number时异常。
修改：用":" split后取port，过滤随机端口时用port，拼接key时用ip:port