### PR TITLE
modify springboot appname's profiling&&fix duplicate define class error when springboot start 

### DIFF
--- a/com.creditease.uav.hook.httpclients/src/main/java/com/creditease/uav/hook/httpclients3/sync/HttpClient3HookProxy.java
+++ b/com.creditease.uav.hook.httpclients/src/main/java/com/creditease/uav/hook/httpclients3/sync/HttpClient3HookProxy.java
@@ -57,8 +57,6 @@ public class HttpClient3HookProxy extends HookProxy {
 
         switch (evt) {
             case SPRING_BEAN_REGIST:
-            case WEBCONTAINER_RESOURCE_INIT:
-                break;
             case WEBCONTAINER_INIT:
                 InsertInterceptToClients(context, webapploader);
                 break;

--- a/com.creditease.uav.monitorframework.agent/src/main/java/com/creditease/uav/monitorframework/adaptors/SpringBootTomcatAdaptor.java
+++ b/com.creditease.uav.monitorframework.agent/src/main/java/com/creditease/uav/monitorframework/adaptors/SpringBootTomcatAdaptor.java
@@ -173,7 +173,7 @@ public class SpringBootTomcatAdaptor extends AbstractAdaptor {
 
                             aa.addLocalVar(m, "mObj", "com.creditease.tomcat.plus.interceptor.SpringBootTomcatPlusIT");
                             m.insertBefore(
-                                    "{mObj=new SpringBootTomcatPlusIT();mObj.startServer(this.getEnvironment().getProperty(\"server.port\"),this.getEnvironment().getProperty(\"server.context-path\"),this);}");
+                                    "{mObj=new SpringBootTomcatPlusIT();mObj.startServer(this.getEnvironment().getProperty(\"server.port\"),this.getEnvironment().getProperty(\"server.context-path\"),this.getEnvironment().getProperty(\"spring.application.name\"),this);}");
                         }
 
                         @Override

--- a/com.creditease.uav.monitorframework.springbootFat/src/main/resources/application.properties
+++ b/com.creditease.uav.monitorframework.springbootFat/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 server.port=8090
 server.display-name=SpringApp
-server.context-path=/app
+server.context-path=/
 logging.path=F:\\Files
 logging.level.root=info
+spring.application.name=SpringCloudApp

--- a/com.creditease.uav.tomcat.plus.core/src/main/java/com/creditease/tomcat/plus/interceptor/SpringBootTomcatPlusIT.java
+++ b/com.creditease.uav.tomcat.plus.core/src/main/java/com/creditease/tomcat/plus/interceptor/SpringBootTomcatPlusIT.java
@@ -43,11 +43,12 @@ public class SpringBootTomcatPlusIT extends TomcatPlusIT {
     /**
      * startUAVServer
      */
-    public void startServer(String port, String contextPath, Object arg) {
+    public void startServer(String port, String contextPath, String appName, Object arg) {
 
         if (!"AnnotationConfigEmbeddedWebApplicationContext".equals(arg.getClass().getSimpleName())) {
             return;
         }
+
         // integrate Tomcat log
         UAVServer.instance().setLog(new TomcatLog("MonitorServer"));
         // start Monitor Server when server starts
@@ -59,7 +60,8 @@ public class SpringBootTomcatPlusIT extends TomcatPlusIT {
                 DataConvertHelper.toInt(port, 8080));
         InterceptSupport iSupport = InterceptSupport.instance();
         // this context will be transmited from springboot mainThread to webcontainerInit thread then back to mainThread
-        iSupport.getThreadLocalContext(Event.WEBCONTAINER_STARTED);
+        InterceptContext context = iSupport.getThreadLocalContext(Event.WEBCONTAINER_STARTED);
+        context.put(InterceptConstants.APPNAME, appName);
     }
 
     /**
@@ -69,11 +71,8 @@ public class SpringBootTomcatPlusIT extends TomcatPlusIT {
      */
     public void setAppid(String contextPath) {
 
-        if (contextPath == null) {
+        if (contextPath == null || "/".equals(contextPath)) {
             contextPath = "";
-        }
-        else if (contextPath.indexOf("/") == 0) {
-            contextPath = contextPath.substring(1);
         }
 
         System.setProperty("com.creditease.uav.appid", MonitorServerUtil.getApplicationId(contextPath, ""));
@@ -274,7 +273,10 @@ public class SpringBootTomcatPlusIT extends TomcatPlusIT {
         String contextPath = (String) ReflectHelper.getField(StandardContext.class, sc, "encodedPath", true);
         context.put(InterceptConstants.CONTEXTPATH, contextPath);
 
-        context.put(InterceptConstants.APPNAME, ReflectHelper.getField(StandardContext.class, sc, "displayName", true));
+        if (context.get(InterceptConstants.APPNAME) == null) {
+            context.put(InterceptConstants.APPNAME,
+                    ReflectHelper.getField(StandardContext.class, sc, "displayName", true));
+        }
 
         ServletContext sContext = (ServletContext) ReflectHelper.getField(StandardContext.class, sc, "context", true);
 
@@ -386,7 +388,7 @@ public class SpringBootTomcatPlusIT extends TomcatPlusIT {
      */
     public void onSpringBeanRegist(String contextPath) {
 
-        if (contextPath == null) {
+        if (contextPath == null || "/".equals(contextPath)) {
             contextPath = "";
         }
         InterceptSupport iSupport = InterceptSupport.instance();


### PR DESCRIPTION
Issue#134 

1.modify springboot appname's profiling，prefer configuration 'spring.application.name' rather than 'server.display-name'.

2.fix duplicate define class error when springboot config contextpath as '/'.