### PR TITLE
FIX at Windows 2003 Server cmd.exe and wmic.exe which generated by UAVStack uavagent running can not be automatically closed

### DIFF
--- a/com.creditease.uav.helper/src/main/java/com/creditease/agent/helpers/RuntimeHelper.java
+++ b/com.creditease.uav.helper/src/main/java/com/creditease/agent/helpers/RuntimeHelper.java
@@ -68,6 +68,8 @@ public class RuntimeHelper {
                 in = ps.getInputStream();
 
                 ein = ps.getErrorStream();
+                
+                ps.getOutputStream().close();
 
                 br = new BufferedReader(new InputStreamReader(in));
                 String line;


### PR DESCRIPTION
#153 
现象:在一个Windows 2003
Server环境中，当安装了MA并使用MA中的start.bat启动之后发现连接数和服务进程可以正常显示，但监控代理程序中的CPU使用率、内存使用率等进程性能指标无法正常采集；在运行一段时间之后发现连接数和服务进程都无法正常显示了，此时观察系统发现系统异常卡顿，甚至无法正常启动其他程序；打开任务管理器之后发现内存使用率飙高，后台启动了大量的cmd.exe与wmic.exe无法关闭，并且cmd.exe与wmic.exe的数量越来越多。

原因：原因是RuntimeHelper的RunTimeTask对Runtime.getRuntime().exec存在漏洞，在Linux和Win
7/10等系统中系统层面标准输入设备会自动关闭，而在win2003 server上不会。 
代码 Process ps = Runtime.getRuntime().exec(...) 每个process有3个标准输入/输出设备， 
•ps.getInputStream() 标准输出 
•ps.getErrorStream() 标准错误输出
•ps.getOutputStream 标准输入
ps.getOutputStream没有关闭导致wmic被hang住

修复方式：增加语句ps.getOutputStream().close();关闭标准输入设备