### PR TITLE
Appid is ‘’ if the last character of basePath is ‘/’

### DIFF
--- a/com.creditease.uav.monitorframework/src/main/java/com/creditease/uav/util/MonitorServerUtil.java
+++ b/com.creditease.uav.monitorframework/src/main/java/com/creditease/uav/util/MonitorServerUtil.java
@@ -328,6 +328,14 @@ public class MonitorServerUtil {
             else {
                 String tmp = basePath.replace("\\", "/");
                 int index = tmp.lastIndexOf("/");
+                
+                /** 
+                 * "/app/xxxxx/" remove the last "/" to get the appid 
+                 */ 
+                if (index == tmp.length() - 1) { 
+                    tmp = tmp.substring(0, tmp.length() - 1); 
+                    index = tmp.lastIndexOf("/"); 
+                }
 
                 appid = tmp.substring(index + 1);
             }


### PR DESCRIPTION
https://github.com/uavorg/uavstack/issues/151

修复如果basePath最后一位为/，获取的appid为空问题