### PR TITLE
FIX logback hook type conversion exception

### DIFF
--- a/com.creditease.uav.loghook/src/main/java/com/creditease/uav/log/hook/LogBackHookProxy.java
+++ b/com.creditease.uav.loghook/src/main/java/com/creditease/uav/log/hook/LogBackHookProxy.java
@@ -103,7 +103,13 @@ public class LogBackHookProxy extends HookProxy {
      */
     private void figureOutLogBackConfig(HookContext context, ClassLoader webapploader) {
 
-        Logger logback = (Logger) LoggerFactory.getLogger(LogBackHookProxy.class);
+        org.slf4j.Logger slflogger = LoggerFactory.getLogger(LogBackHookProxy.class);
+
+        if (!(slflogger instanceof Logger)) {
+            return;
+        }
+
+        Logger logback = (Logger) slflogger;
 
         InterceptContext interceptContext = (InterceptContext) context.get(HookConstants.INTERCEPTCONTEXT);
 


### PR DESCRIPTION
问题：应用中同时使用logback和log4j等时，因org.slf4j.LoggerFactory.getLogger()可能获取到非logback的logger，转换为ch.qos.logback.classic.Logger时异常
修改：对获取的logger增加类型判断，是ch.qos.logback.classic.Logger才做转换，否则返回