### PR TITLE
The memory leak problem of apphubManager

### DIFF
--- a/com.creditease.uav.healthmanager.buildComponent/bin/run.sh
+++ b/com.creditease.uav.healthmanager.buildComponent/bin/run.sh
@@ -27,7 +27,7 @@ export CLASSPATH=bin/com.creditease.uav.base-1.0-boot.jar
 echo $CLASSPATH
 javaAgent="-javaagent:../uavmof/com.creditease.uav.agent/com.creditease.uav.monitorframework.agent-1.0-agent.jar"
 javaOpts="-server -Xms256m -Xss256k -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:+CMSIncrementalPacing -XX:CMSIncrementalDutyCycleMin=0 -XX:CMSIncrementalDutyCycle=10 -XX:+UseParNewGC -XX:+UseCMSCompactAtFullCollection -XX:-CMSParallelRemarkEnabled -XX:CMSFullGCsBeforeCompaction=0 -XX:CMSInitiatingOccupancyFraction=70 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=."
-$executeJava $javaAgent $3 $javaOpts -XX:OnOutOfMemoryError='kill -9 %p' -DNetCardIndex=0 -DJAppID=$1 -DJAppGroup=UAV -classpath $CLASSPATH com.creditease.mscp.boot.MSCPBoot -p $2 &
+$executeJava $javaAgent $3 $javaOpts -XX:OnOutOfMemoryError='kill -9 %p' -DNetCardIndex=0 -DJAppID=$1 -DJAppGroup=UAV -Dsun.net.httpserver.maxReqTime=300 -Dsun.net.httpserver.maxRspTime=300 -classpath $CLASSPATH com.creditease.mscp.boot.MSCPBoot -p $2 &
 
 # add crontab process watcher
 if [ "$proc_watcher" == "yes" ]; then

--- a/com.creditease.uav.healthmanager.buildComponent/config/agent.properties
+++ b/com.creditease.uav.healthmanager.buildComponent/config/agent.properties
@@ -271,7 +271,7 @@ feature.apphubmanager.http.port=8011
 feature.apphubmanager.http.backlog=10
 feature.apphubmanager.http.core=10
 feature.apphubmanager.http.max=50
-feature.apphubmanager.http.bqsize=10
+feature.apphubmanager.http.bqsize=100
 #feature.DBSource.AppHubMgt
 feature.apphubmanager.ds.enable=true
 feature.apphubmanager.ds.servers=127.0.0.1:27017

--- a/com.creditease.uav.healthmanager/src/main/java/com/creditease/uav/feature/AppHubManager.java
+++ b/com.creditease.uav.healthmanager/src/main/java/com/creditease/uav/feature/AppHubManager.java
@@ -60,6 +60,8 @@ public class AppHubManager extends AgentFeatureComponent {
         @SuppressWarnings({ "rawtypes", "unchecked" })
         ThreadPoolExecutor exe = new ThreadPoolExecutor(core, max, 30000, TimeUnit.MILLISECONDS,
                 new ArrayBlockingQueue(bqsize));
+        // 调用线程执行多余任务
+        exe.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         apphubManagerServerListenWorker.start(exe, port, backlog);
 
         if (log.isTraceEnable()) {


### PR DESCRIPTION
#335 
在apphubManager多线程处理大量http请求时，
 1.增加线程拒绝策略，
 2.同时加大队列大小，
 3.启动时设置请求和相应超时时间，
增强代码在处理大量http请求时的健壮性.