### PR TITLE
fix URI has "null" substring bug and remove excrescent path in appid

### DIFF
--- a/com.creditease.uav.monitorframework/src/main/java/com/creditease/uav/profiling/handlers/ClientProfileHandler.java
+++ b/com.creditease.uav.monitorframework/src/main/java/com/creditease/uav/profiling/handlers/ClientProfileHandler.java
@@ -134,7 +134,7 @@ public class ClientProfileHandler extends BaseComponent implements ProfileHandle
 
         if (clientURL.startsWith("http")) {
             String rs = (String) context.get(ProfileConstants.PC_ARG_CLIENT_RS);
-            if(StringHelper.isNaturalNumber(rs)) {
+            if (StringHelper.isNaturalNumber(rs)) {
                 urlAttrs.put(MonitorServerUtil.getActionTag(rs), curTime);
             }
         }
@@ -147,8 +147,29 @@ public class ClientProfileHandler extends BaseComponent implements ProfileHandle
      */
     private ProfileElementInstance getTargetURIInst(URI clientTargetURI, ProfileElement elem) {
 
+        String uri = clientTargetURI.getScheme() + "://";
         String host = clientTargetURI.getHost();
-        int port = clientTargetURI.getPort();
+
+        // According the analysis function in Java.Net.URI, char '_' is treated as Illegal character in host name.
+        // It makes a URISyntaxException when parse URI string.
+        if (host == null){
+            String authority = clientTargetURI.getAuthority();
+            // if the authority part contains user info
+            int index = authority.indexOf("@");
+            if (index >= 0){
+                uri += authority.substring(index + 1);
+            }else{
+                uri += authority;
+            }
+        }
+        else{
+            uri += host;
+            int port = clientTargetURI.getPort();
+            if (port > 0){
+                uri += ":" + port;
+            }
+        }
+
         // String dnsName = null;
         //
         // if (!NetworkHelper.isIPV4(host)) {
@@ -158,12 +179,6 @@ public class ClientProfileHandler extends BaseComponent implements ProfileHandle
         // host = tmp;
         // }
         // }
-
-        String uri = clientTargetURI.getScheme() + "://" + host;
-        if (port > 0) {
-            uri += ":" + port;
-        }
-
         // http://xxxxx/yyyyy@client type
         ProfileElementInstance pei = elem.getInstance(uri);
 

--- a/com.creditease.uav.monitorframework/src/main/java/com/creditease/uav/util/MonitorServerUtil.java
+++ b/com.creditease.uav.monitorframework/src/main/java/com/creditease/uav/util/MonitorServerUtil.java
@@ -624,28 +624,23 @@ public class MonitorServerUtil {
         if ("".equals(contextroot)) {
             /*
              * NOTE: springboot's basePath is a random temp directory,so we use main(usually the jar name) as the appid
+             * 
              */
             if (UAVServer.instance().getServerInfo(CaptureConstants.INFO_APPSERVER_VENDOR)
                     .equals(UAVServer.ServerVendor.SPRINGBOOT)) {
                 String javaCommand = System.getProperty("sun.java.command");
                 appid = javaCommand.split(" ")[0];
+            }else {
+                appid = basePath;
             }
-            else {
-                String tmp = basePath.replace("\\", "/");
-                int index = tmp.lastIndexOf("/");
-                
-                /** 
-                 * "/app/xxxxx/" remove the last "/" to get the appid 
-                 */ 
-                if (index == tmp.length() - 1) { 
-                    tmp = tmp.substring(0, tmp.length() - 1); 
-                    index = tmp.lastIndexOf("/"); 
-                }
-                appid = tmp.substring(index + 1);
-            }
+            appid = getReducedPath(appid);
         }
         else {
             appid = contextroot;
+            if (UAVServer.instance().getServerInfo(CaptureConstants.INFO_APPSERVER_VENDOR)
+                    .equals(UAVServer.ServerVendor.SPRINGBOOT)) {
+                appid = getReducedPath(appid);
+            }
         }
 
         // 去除最开始的"/"
@@ -660,5 +655,22 @@ public class MonitorServerUtil {
         appid = appid.replace("/", "--").replace("\\", "--");
         
         return appid;
+    }
+    
+    /*
+     * 获取给定路径的最后以层目录
+                    例如：给定目录 abc/def/
+                    输出：def
+     */
+    private static String getReducedPath(String path) {
+        if (path == null || path.equals(""))
+            return "";
+        String reducedPath = path.replace("\\", "/");
+        int index = reducedPath.lastIndexOf("/");
+        if (index == reducedPath.length() - 1) {
+            reducedPath = reducedPath.substring(0, reducedPath.length() - 1);
+            index = reducedPath.lastIndexOf("/");
+        }
+        return reducedPath.substring(index + 1);
     }
 }

--- a/com.creditease.uav.tomcat.plus.core/src/main/java/com/creditease/tomcat/plus/interceptor/SpringBootTomcatPlusIT.java
+++ b/com.creditease.uav.tomcat.plus.core/src/main/java/com/creditease/tomcat/plus/interceptor/SpringBootTomcatPlusIT.java
@@ -58,7 +58,7 @@ public class SpringBootTomcatPlusIT extends TomcatPlusIT {
         // start Monitor Server when server starts
         UAVServer.instance().start(new Object[] { UAVServer.ServerVendor.SPRINGBOOT });
         // set appid
-        setAppid(contextPath);
+        //setAppid(contextPath);
         // set the connector port
         UAVServer.instance().putServerInfo(CaptureConstants.INFO_APPSERVER_LISTEN_PORT,
                 DataConvertHelper.toInt(port, 8080));
@@ -73,10 +73,19 @@ public class SpringBootTomcatPlusIT extends TomcatPlusIT {
      * 
      * @param contextPath
      */
+    @Deprecated
     public void setAppid(String contextPath) {
 
         if (contextPath == null || "/".equals(contextPath)) {
             contextPath = "";
+        }else{
+            contextPath = contextPath.replace("\\", "/");
+            int index = contextPath.lastIndexOf("/");
+            if (index == contextPath.length() - 1){
+                contextPath = contextPath.substring(0, contextPath.length() - 1);
+                index = contextPath.lastIndexOf("/");
+            }
+            contextPath = contextPath.substring(index + 1);
         }
 
         System.setProperty("com.creditease.uav.appid", MonitorServerUtil.getApplicationId(contextPath, ""));


### PR DESCRIPTION
https://github.com/uavorg/uavstack/issues/356
fix bug in ClientProfileHandler.class, the bug caused by special char in URL string, when parse the string into a URI Object, java.net.URL class will devide string into several parts and analysis each substring. when special character appears in "hostname" part of one URI string, it makes a URISyntaxException and an analyse fault. When we call function "getHost()",it returns null.