### PR TITLE
invokechain enhancement for rabbitmq and low version tomcat

### DIFF
--- a/com.creditease.uav.hook.mq/src/main/java/com/creditease/uav/hook/rabbitmq/interceptors/RabbitmqIT.java
+++ b/com.creditease.uav.hook.mq/src/main/java/com/creditease/uav/hook/rabbitmq/interceptors/RabbitmqIT.java
@@ -292,8 +292,8 @@ public class RabbitmqIT extends BaseComponent {
                         && props.getHeaders().containsKey(InvokeChainConstants.PARAM_MQHEAD_SPANINFO)) {
                     params.put(InvokeChainConstants.PARAM_MQHEAD_SPANINFO,
                             props.getHeaders().get(InvokeChainConstants.PARAM_MQHEAD_SPANINFO) + "");
-                    params.put(CaptureConstants.INFO_APPSERVER_CONNECTOR_REQUEST_URL, url);
                 }
+                params.put(CaptureConstants.INFO_APPSERVER_CONNECTOR_REQUEST_URL, url);
 
                 // register adapter
                 UAVServer.instance().runSupporter("com.creditease.uav.apm.supporters.InvokeChainSupporter",

--- a/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/slowoper/adapter/ServerSpanAdapter.java
+++ b/com.creditease.uav.monitorframework.apm/src/main/java/com/creditease/uav/apm/slowoper/adapter/ServerSpanAdapter.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.creditease.agent.helpers.JSONHelper;
+import com.creditease.agent.helpers.ReflectionHelper;
 import com.creditease.monitor.UAVServer;
 import com.creditease.monitor.captureframework.spi.CaptureConstants;
 import com.creditease.uav.apm.RewriteIvcRequestWrapper;
@@ -147,8 +148,46 @@ public class ServerSpanAdapter extends InvokeChainAdapter {
     private String getResponHeaders(HttpServletResponse response) {
 
         Map<String, String> result = new HashMap<String, String>();
-        for (String key : response.getHeaderNames()) {
-            result.put(key, response.getHeader(key));
+
+        try {
+            for (String key : response.getHeaderNames()) {
+                result.put(key, response.getHeader(key));
+            }
+        }
+        catch (Error e) {
+            Object resp = response;
+            // 重调用链开启后这里的response是RewriteIvcResponseWrapper
+            if ("com.creditease.uav.apm.RewriteIvcResponseWrapper".equals(response.getClass().getName())) {
+                resp = ReflectionHelper.getField(response.getClass(), response, "response");
+                if (resp == null) {
+                    return JSONHelper.toString(result);
+                }
+            }
+            if (resp == null) {
+                return JSONHelper.toString(result);
+            }
+            // for tomcat 6.0.4x
+            if ("org.apache.catalina.connector.ResponseFacade".equals(resp.getClass().getName())) {
+                resp = ReflectionHelper.getField(resp.getClass(), resp, "response");
+                if (resp == null) {
+                    return JSONHelper.toString(result);
+                }
+
+                String[] headerNames = (String[]) ReflectionHelper.invoke(resp.getClass().getName(), resp,
+                        "getHeaderNames", null, null, response.getClass().getClassLoader());
+                if (headerNames == null) {
+                    return JSONHelper.toString(result);
+                }
+
+                for (String headerName : headerNames) {
+                    String headerValue = (String) ReflectionHelper.invoke(resp.getClass().getName(), resp, "getHeader",
+                            new Class[] { String.class }, new Object[] { headerName },
+                            response.getClass().getClassLoader());
+                    if (headerValue != null) {
+                        result.put(headerName, headerValue);
+                    }
+                }
+            }
         }
         return JSONHelper.toString(result);
     }


### PR DESCRIPTION
#359 #360 
说明:
1,tomcat6.0.4系列使用servlet2.5的api,其中response接口中没有getStatus和getHeader方法,会导致异常.
2,rabbitmq调用链在produce未安装uav时,此处的mqheader中不含有span的信息,但是该请求的url是存在的,应该在if外进行记录
enhance :
1,从tomcat返回的reponsefacade中获取其持有的response对象,该对象含有getstatus和getHeader方法,同时对于开启重调用链对response加的壳进行脱壳处理.
2,将url移动到span是否存在判断的if语句外面进行获取
