### PR TITLE
FIX HttpRequest does'nt contain ip:port causing httpclient profile without http://ip:port 

### DIFF
--- a/com.creditease.uav.hook.httpclients/src/main/java/com/creditease/uav/hook/httpclients/async/interceptors/ApacheAsyncHttpClientIT.java
+++ b/com.creditease.uav.hook.httpclients/src/main/java/com/creditease/uav/hook/httpclients/async/interceptors/ApacheAsyncHttpClientIT.java
@@ -376,6 +376,11 @@ public class ApacheAsyncHttpClientIT extends BaseComponent {
             RequestLine rl = hr.getRequestLine();
             httpAction = rl.getMethod();
             targetURL = rl.getUri();
+            
+            // 部分HttpRequest中没有ip:port，需要从httpHost中拿到再拼接
+            if (!targetURL.startsWith("http")) {
+                targetURL = requestProducer.getTarget().toURI() + targetURL;
+            }
         }
         catch (IOException e) {
             // ignore thie exception

--- a/com.creditease.uav.hook.httpclients/src/main/java/com/creditease/uav/hook/httpclients/sync/interceptors/ApacheHttpClientIT.java
+++ b/com.creditease.uav.hook.httpclients/src/main/java/com/creditease/uav/hook/httpclients/sync/interceptors/ApacheHttpClientIT.java
@@ -117,6 +117,11 @@ public class ApacheHttpClientIT extends BaseComponent {
         httpAction = rl.getMethod();
         targetURl = rl.getUri();
 
+        // 部分HttpRequest中没有ip:port，需要从httpHost中拿到再拼接
+        if (!targetURl.startsWith("http")) {
+            targetURl = target.toURI() + targetURl;
+        }
+
         Map<String, Object> params = new HashMap<String, Object>();
 
         params.put(CaptureConstants.INFO_CLIENT_REQUEST_URL, targetURl);

--- a/com.creditease.uav.hook.httpclients/src/main/java/com/creditease/uav/hook/httpclients3/sync/interceptors/ApacheHttpClient3IT.java
+++ b/com.creditease.uav.hook.httpclients/src/main/java/com/creditease/uav/hook/httpclients3/sync/interceptors/ApacheHttpClient3IT.java
@@ -101,6 +101,11 @@ public class ApacheHttpClient3IT extends BaseComponent {
         try {
             httpAction = method.getName();
             targetURL = method.getURI().toString();
+
+            // HttpMethod中可能不包含ip:port，需要从httpHost中拿到再拼接
+            if (!targetURL.startsWith("http")) {
+                targetURL = hostconfig.getHostURL() + targetURL;
+            }
         }
         catch (URIException e) {
             // ignore


### PR DESCRIPTION
http请求中HttpRequest中可能不包含ip:port导致httpclient画像没有http://ip:port，
如拿到的url不含"http"则获取HttpHost与其拼接
