### PR TITLE
Apphub Authorized user experience enhancement 

### DIFF
--- a/com.creditease.uav.console/src/main/webapp/uavapp_godfilter/groupfilter/js/groupfilter.js
+++ b/com.creditease.uav.console/src/main/webapp/uavapp_godfilter/groupfilter/js/groupfilter.js
@@ -174,6 +174,7 @@ function showAddDiv(){
 	$("#addEmailListName").val("");
 	DataBindClass.userEditInfo={};
 	
+	PageClass.ajaxGProfile();
 	initGroupSelect("addGroupList","save");
 	
     $("#addGroupFilterDiv").modal({backdrop: 'static', keyboard: false});


### PR DESCRIPTION
https://github.com/uavorg/uavstack/issues/369

Apphub 服务治理--监控授权：

UAV应用下线后，在UAV容器监控中，定义的AppGroup（JAppGroup）将会不存在，

此时授权编辑时，将已经不存在的AppGroup屏蔽显示，

当用户页面提交的时候，自然不会有该数据提交，达到对授权信息删除垃圾数据的效果

代码补充