### PR TITLE
Base component SystemForkjoinWorker modification

### DIFF
--- a/com.creditease.uav.agent/src/main/java/com/creditease/agent/feature/logagent/TaildirLogComponent.java
+++ b/com.creditease.uav.agent/src/main/java/com/creditease/agent/feature/logagent/TaildirLogComponent.java
@@ -287,7 +287,7 @@ public class TaildirLogComponent extends AbstractComponent {
                     job.put("reader", reader);
                     job.put("TailLogcomp", this);
 
-                    executor.submitTask(job);
+                    executor.submit(job);
 
                     job.waitAllTaskDone();
 

--- a/com.creditease.uav.base/src/main/java/com/creditease/agent/spi/IForkjoinWorker.java
+++ b/com.creditease.uav.base/src/main/java/com/creditease/agent/spi/IForkjoinWorker.java
@@ -20,23 +20,37 @@
 
 package com.creditease.agent.spi;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.Future;
+
 public interface IForkjoinWorker {
 
     public String getName();
 
     public String getFeature();
 
-    public void submitTask(AbstractPartitionJob task);
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks);
+
+    public <T> ForkJoinTask<T> submit(ForkJoinTask<T> task);
+
+    public <T> ForkJoinTask<T> submit(Callable<T> task);
+
+    public <T> ForkJoinTask<T> submit(Runnable task, T result);
+
+    public ForkJoinTask<?> submit(Runnable task);
 
     public void shutdown();
 
-    public void getParallelism();
+    public int getParallelism();
 
-    public void getRunningThreadCount();
+    public int getRunningThreadCount();
 
-    public void getPoolSize();
+    public int getPoolSize();
 
-    public void getQueuedTaskCount();
+    public long getQueuedTaskCount();
 
     @Override
     public String toString();

--- a/com.creditease.uav.base/src/main/java/com/creditease/agent/workqueue/SystemForkjoinWorker.java
+++ b/com.creditease.uav.base/src/main/java/com/creditease/agent/workqueue/SystemForkjoinWorker.java
@@ -20,10 +20,14 @@
 
 package com.creditease.agent.workqueue;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.Future;
 
 import com.creditease.agent.spi.AbstractComponent;
-import com.creditease.agent.spi.AbstractPartitionJob;
 import com.creditease.agent.spi.IForkjoinWorker;
 
 /**
@@ -43,12 +47,48 @@ public class SystemForkjoinWorker extends AbstractComponent implements IForkjoin
     }
 
     /*
+     * invokeAll方法
+     */
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) {
+
+        return executor.invokeAll(tasks);
+    }
+
+    /*
      * submit方法
      */
     @Override
-    public void submitTask(AbstractPartitionJob task) {
+    public <T> ForkJoinTask<T> submit(ForkJoinTask<T> task) {
 
-        executor.submit(task);
+        return executor.submit(task);
+    }
+
+    /*
+     * submit方法
+     */
+    @Override
+    public <T> ForkJoinTask<T> submit(Callable<T> task) {
+
+        return executor.submit(task);
+    }
+
+    /*
+     * submit方法
+     */
+
+    @Override
+    public <T> ForkJoinTask<T> submit(Runnable task, T result) {
+
+        return executor.submit(task, result);
+    }
+
+    /*
+     * submit方法
+     */
+    @Override
+    public ForkJoinTask<?> submit(Runnable task) {
+
+        return executor.submit(task);
     }
 
     /*
@@ -66,36 +106,36 @@ public class SystemForkjoinWorker extends AbstractComponent implements IForkjoin
      * parallelism level of this pool
      */
     @Override
-    public void getParallelism() {
+    public int getParallelism() {
 
-        executor.getParallelism();
+        return executor.getParallelism();
     }
 
     /*
      * Returns an estimate of the number of worker threads
      */
     @Override
-    public void getRunningThreadCount() {
+    public int getRunningThreadCount() {
 
-        executor.getRunningThreadCount();
+        return executor.getRunningThreadCount();
     }
 
     /*
      * Returns the number of worker threads
      */
     @Override
-    public void getPoolSize() {
+    public int getPoolSize() {
 
-        executor.getPoolSize();
+        return executor.getPoolSize();
     }
 
     /*
      * Returns the number of queued tasks
      */
     @Override
-    public void getQueuedTaskCount() {
+    public long getQueuedTaskCount() {
 
-        executor.getQueuedTaskCount();
+        return executor.getQueuedTaskCount();
     }
 
     /*

--- a/com.creditease.uav.collect/src/main/java/com/creditease/uav/collect/client/copylogagent/CopyOfProcessOfLogagent.java
+++ b/com.creditease.uav.collect/src/main/java/com/creditease/uav/collect/client/copylogagent/CopyOfProcessOfLogagent.java
@@ -137,7 +137,7 @@ public class CopyOfProcessOfLogagent {
                 job.put("reader", reader);
                 job.put("TailLogcomp", this);
 
-                executor.submitTask(job);
+                executor.submit(job);
 
                 job.waitAllTaskDone();
 


### PR DESCRIPTION
https://github.com/uavorg/uavstack/issues/387
当前SystemForkjoinWorker对ForkJoinPool的封装限制太死，使用起来很不方便，修改如下：

1.增加提交task进ForkJoinPool的方法，支持所有类型的提交，包括Runnable、Callable、ForkJoinTask

2.增加getter返回类型

3.修改原LogAgent中使用的SystemForkjoinWorker的方法