### PR TITLE
fix NPE problems caused by repeated registration of filters and servlets &&  adapt the context path configuration in springboot 2+

### DIFF
--- a/com.creditease.uav.monitorframework.agent/src/main/java/com/creditease/uav/monitorframework/adaptors/SpringBootTomcatAdaptor.java
+++ b/com.creditease.uav.monitorframework.agent/src/main/java/com/creditease/uav/monitorframework/adaptors/SpringBootTomcatAdaptor.java
@@ -20,10 +20,42 @@
 
 package com.creditease.uav.monitorframework.adaptors;
 
+import com.creditease.agent.helpers.ReflectionHelper;
+
 import javassist.ClassPool;
 import javassist.CtMethod;
 
 public class SpringBootTomcatAdaptor extends AbstractAdaptor {
+
+    private String springBootVersion = "";
+
+    private void getSpringBootVersion(ClassLoader clsLoader, String className) {
+
+        if (!"".equals(springBootVersion) || clsLoader == null) {
+            return;
+        }
+
+        /**
+         * NOTE:this class is used to detect springboot version. it exists in all versions of springboot, and we
+         * probably will never inject this class.
+         */
+        String versionDetectClassName = "org.springframework.boot.Banner";
+
+        if (versionDetectClassName.equals(className)) {
+            return;
+        }
+
+        Class<?> springBootVersionDetectClass = ReflectionHelper.tryLoadClass(versionDetectClassName, clsLoader);
+
+        if (springBootVersionDetectClass == null) {
+            return;
+        }
+
+        Package pkg = springBootVersionDetectClass.getPackage();
+        String version = (pkg != null) ? pkg.getImplementationVersion() : null;
+        springBootVersion = (version != null) ? version : "UnKnownVersion";
+        System.out.println("MOF.ApplicationVersion=SpringBoot " + springBootVersion);
+    }
 
     @Override
     public byte[] onStartup(ClassLoader clsLoader, String uavMofRoot, String className) {
@@ -104,6 +136,8 @@ public class SpringBootTomcatAdaptor extends AbstractAdaptor {
 
     @Override
     public byte[] onLoadClass(ClassLoader clsLoader, final String uavMofRoot, String className) {
+
+        getSpringBootVersion(clsLoader, className);
 
         this.addClassPath(clsLoader);
 
@@ -243,8 +277,13 @@ public class SpringBootTomcatAdaptor extends AbstractAdaptor {
                         public void process(CtMethod m) throws Exception {
 
                             aa.addLocalVar(m, "mObj", "com.creditease.tomcat.plus.interceptor.SpringBootTomcatPlusIT");
-                            m.insertBefore(
-                                    "{mObj=new SpringBootTomcatPlusIT();mObj.startServer(this.getEnvironment().getProperty(\"server.port\"),this.getEnvironment().getProperty(\"server.context-path\"),this.getEnvironment().getProperty(\"spring.application.name\"),this);mObj.onSpringBeanRegist(new Object[]{this,this.getEnvironment().getProperty(\"server.context-path\")});}");
+                            String contextPathKey = springBootVersion.startsWith("2") ? "server.servlet.context-path"
+                                    : "server.context-path";
+                            String sb = "{mObj = new SpringBootTomcatPlusIT();"
+                                    + "mObj.startServer(this.getEnvironment().getProperty(\"server.port\"),this.getEnvironment().getProperty(\"spring.application.name\"),this);"
+                                    + "mObj.onSpringBeanRegist(new Object[]{this,this.getEnvironment().getProperty(\""
+                                    + contextPathKey + "\")});}";
+                            m.insertBefore(sb);
                             m.insertAfter("{mObj.onSpringFinishRefresh(this);}");
 
                         }

--- a/com.creditease.uav.monitorframework/src/main/java/com/creditease/monitor/jee/servlet30/DynamicServletContextProcessor.java
+++ b/com.creditease.uav.monitorframework/src/main/java/com/creditease/monitor/jee/servlet30/DynamicServletContextProcessor.java
@@ -94,11 +94,16 @@ public class DynamicServletContextProcessor extends JDKProxyInvokeProcessor<Serv
 
         if (methodName.equals("addServlet")) {
 
-            servlets.add((ServletRegistration.Dynamic) res);
+            if (res != null) {
+                servlets.add((ServletRegistration.Dynamic) res);
+            }
         }
         else if (methodName.equals("addFilter")) {
 
-            filters.add((FilterRegistration.Dynamic) res);
+            // if the filter has already been registered,the res will be null;
+            if (res != null) {
+                filters.add((FilterRegistration.Dynamic) res);
+            }
         }
         else if (methodName.equals("addListener")) {
 

--- a/com.creditease.uav.tomcat.plus.core/src/main/java/com/creditease/tomcat/plus/interceptor/SpringBootTomcatPlusIT.java
+++ b/com.creditease.uav.tomcat.plus.core/src/main/java/com/creditease/tomcat/plus/interceptor/SpringBootTomcatPlusIT.java
@@ -47,7 +47,7 @@ public class SpringBootTomcatPlusIT extends TomcatPlusIT {
     /**
      * startUAVServer
      */
-    public void startServer(String port, String contextPath, String appName, Object arg) {
+    public void startServer(String port, String appName, Object arg) {
 
         if(!isWebServerContext(arg)) {
             return;


### PR DESCRIPTION
#394  #395 
issue：
1.重复注册filter和servlet导致NPE问题
2.springboot2.0.0以后设置contextpath的key从server.context-path变成server.servlet.context-path,导致获取的contextpath与hook时的contextPath不一致导致异常

fix：
1.增加判空条件
2.在启动过程中获取springboot的版本进行相应的适配