### PR TITLE
Modify log and APM ES Index

### DIFF
--- a/com.creditease.uav.console/src/main/webapp/uavapp_godeye/appmonitor/js/uav.apm.js
+++ b/com.creditease.uav.console/src/main/webapp/uavapp_godeye/appmonitor/js/uav.apm.js
@@ -534,8 +534,8 @@ function APMTool(app) {
 
 		html+="&nbsp;<button type=\"button\" class=\"btn btn-info\" title=\"查看最近1分钟内的服务请求\" onclick='appAPM.callIVCQuery(\"lst1min\",{appuuid:\""+this.appInfo["appuuid"]+"\",appurl:\""+this.appInfo["appurl"]+"\",appid:\""+this.appInfo["appid"]+"\"})'>L1min</button>"+
 				"&nbsp;<button type=\"button\" class=\"btn btn-info\" title=\"查看1小时内最慢100条的服务请求\" onclick='appAPM.callIVCQuery(\"slow100in1hr\",{appuuid:\""+this.appInfo["appuuid"]+"\",appurl:\""+this.appInfo["appurl"]+"\",appid:\""+this.appInfo["appid"]+"\"})'>s100in1hr</button>" +
-		        "&nbsp;<button type=\"button\" class=\"btn btn-info\" title=\"查看24小时内最近100条的服务请求\"  onclick='appAPM.callIVCQuery(\"lst100\",{appuuid:\""+this.appInfo["appuuid"]+"\",appurl:\""+this.appInfo["appurl"]+"\",appid:\""+this.appInfo["appid"]+"\"})'>L100</button>" +
-		        "&nbsp;<button type=\"button\" class=\"btn btn-info\" title=\"查看24小时内最慢100条的服务请求\" onclick='appAPM.callIVCQuery(\"slow100\",{appuuid:\""+this.appInfo["appuuid"]+"\",appurl:\""+this.appInfo["appurl"]+"\",appid:\""+this.appInfo["appid"]+"\"})'>s100</button></div></div>" ;
+		        "&nbsp;<button type=\"button\" class=\"btn btn-info\" title=\"查看今日最近100条的服务请求\"  onclick='appAPM.callIVCQuery(\"lst100\",{appuuid:\""+this.appInfo["appuuid"]+"\",appurl:\""+this.appInfo["appurl"]+"\",appid:\""+this.appInfo["appid"]+"\"})'>L100</button>" +
+		        "&nbsp;<button type=\"button\" class=\"btn btn-info\" title=\"查看今日最慢100条的服务请求\" onclick='appAPM.callIVCQuery(\"slow100\",{appuuid:\""+this.appInfo["appuuid"]+"\",appurl:\""+this.appInfo["appurl"]+"\",appid:\""+this.appInfo["appid"]+"\"})'>s100</button></div></div>" ;
 		
 		html+="<div  id='AppIVCWnd_TContainer' style='font-size:12px;color:black;'></div>";
 		
@@ -1279,7 +1279,7 @@ function APMTool(app) {
 				dataList=this.mainList;
 				
 				var etime=new Date().getTime();
-				var stime=etime-24*60*60000;
+				var stime=new Date(new Date().toLocaleDateString()).getTime();
 				data["request"]["appuuid"]=appuuid;
 				data["request"]["stime"]=stime+"";
 				data["request"]["etime"]=etime+"";
@@ -1291,7 +1291,7 @@ function APMTool(app) {
 				dataList=this.mainList;
 				
 				var etime=new Date().getTime();
-				var stime=etime-24*60*60000;
+				var stime=new Date(new Date().toLocaleDateString()).getTime();
 				data["request"]["appuuid"]=appuuid;
 				data["request"]["stime"]=stime+"";
 				data["request"]["etime"]=etime+"";

--- a/com.creditease.uav.elasticsearch.client/src/main/java/com/creditease/uav/elasticsearch/index/ESIndexHelper.java
+++ b/com.creditease.uav.elasticsearch.client/src/main/java/com/creditease/uav/elasticsearch/index/ESIndexHelper.java
@@ -1,0 +1,165 @@
+/*-
+ * <<
+ * UAVStack
+ * ==
+ * Copyright (C) 2016 - 2017 UAVStack
+ * ==
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required Of applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * >>
+ */
+
+package com.creditease.uav.elasticsearch.index;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * IndexHelper :获取Index的工具类
+ *
+ */
+public class ESIndexHelper {
+
+    final private static String UAV = "uav_"; // 索引名前缀
+
+    final private static String DATEFORMAT = "yyyy-MM-dd";
+
+    final private static long MILLIS_OF_DAY = 60 * 60 * 24 * 1000L;
+
+    /**
+     * 获取按周记录的索引名，以周的开始（周日）结尾
+     * 
+     * @param prefix
+     * @return
+     */
+    public static String getIndexOfWeek(String prefix) {
+
+        return getIndexOfWeekByMillis(prefix, System.currentTimeMillis());
+    }
+
+    /**
+     * 获取按周记录的索引名
+     * 
+     * @param prefix
+     * @param when
+     *            以当前周为基准第when周，可为负
+     * @return
+     */
+    public static String getIndexOfWeek(String prefix, int when) {
+
+        return getIndexOfWeekByMillis(prefix, System.currentTimeMillis() + 7 * when * MILLIS_OF_DAY);
+    }
+
+    /**
+     * 获取日期对应的按周记录的索引名
+     * 
+     * @param prefix
+     * @param date
+     *            yyyy-MM-dd
+     * @return
+     */
+    public static String getIndexOfWeek(String prefix, String date) {
+
+        Calendar cld = Calendar.getInstance();
+        SimpleDateFormat sdf = new SimpleDateFormat(DATEFORMAT);
+        try {
+            cld.setTime(sdf.parse(date));
+        }
+        catch (ParseException e) {
+            return null;
+        }
+        cld.set(Calendar.DAY_OF_WEEK, 1);
+
+        return UAV + format(prefix) + "_" + sdf.format(cld.getTime());
+    }
+
+    /**
+     * 获取时间戳对应的按周记录的索引名
+     * 
+     * @param prefix
+     * @param timestamp
+     * @return
+     */
+    public static String getIndexOfWeekByMillis(String prefix, long timestamp) {
+
+        Calendar cld = Calendar.getInstance();
+        cld.setTimeInMillis(timestamp);
+        cld.set(Calendar.DAY_OF_WEEK, 1);
+
+        return UAV + format(prefix) + "_" + new SimpleDateFormat(DATEFORMAT).format(cld.getTime());
+
+    }
+
+    /**
+     * 获取按日记录的索引名
+     * 
+     * @param prefix
+     * @return
+     */
+    public static String getIndexOfDay(String prefix) {
+
+        return getIndexOfDayByMillis(prefix, System.currentTimeMillis());
+    }
+
+    /**
+     * 获取按日记录的索引名
+     * 
+     * @param prefix
+     * @param when
+     *            以当日为基准第when日，可为负
+     * @return
+     */
+    public static String getIndexOfDay(String prefix, int when) {
+
+        return getIndexOfDayByMillis(prefix, System.currentTimeMillis() + when * MILLIS_OF_DAY);
+    }
+
+    /**
+     * 获取日期对应的按日记录的索引名
+     * 
+     * @param prefix
+     * @param date
+     *            yyyy-MM-dd
+     * @return
+     */
+    public static String getIndexOfDay(String prefix, String date) {
+
+        SimpleDateFormat sdf = new SimpleDateFormat(DATEFORMAT);
+        try {
+            return UAV + format(prefix) + "_" + sdf.format(sdf.parse(date));
+        }
+        catch (ParseException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 获取时间戳对应的按日记录的索引名
+     * 
+     * @param prefix
+     * @param timestamp
+     * @return
+     */
+    public static String getIndexOfDayByMillis(String prefix, long timestamp) {
+
+        SimpleDateFormat sdf = new SimpleDateFormat(DATEFORMAT);
+        return UAV + format(prefix) + "_" + sdf.format(new Date(timestamp));
+    }
+
+    private static String format(String str) {
+
+        return str.toLowerCase().replace('.', '_');
+    }
+
+}

--- a/com.creditease.uav.elasticsearch.client/src/test/java/com/creditease/uav/elasticsearch/client/DoTestESIndex.java
+++ b/com.creditease.uav.elasticsearch.client/src/test/java/com/creditease/uav/elasticsearch/client/DoTestESIndex.java
@@ -1,0 +1,74 @@
+/*-
+ * <<
+ * UAVStack
+ * ==
+ * Copyright (C) 2016 - 2017 UAVStack
+ * ==
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * >>
+ */
+
+/*-
+ * <<
+ * UAVStack
+ * ==
+ * Copyright (C) 2016 - 2017 UAVStack
+ * ==
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * >>
+ */
+package com.creditease.uav.elasticsearch.client;
+
+import com.creditease.uav.elasticsearch.index.ESIndexHelper;
+
+/**
+ * DoTestESIndex description: 测试ESIndexHelper类
+ *
+ */
+public class DoTestESIndex {
+
+    public static void main(String[] args) {
+
+        String prefix = "apm";
+        String time = "2017-9-6";
+        long timestamp = 1504627200000l;// 2017-9-6 的时间戳
+        // 获取本周的索引
+        System.out.println("获取本周的索引：\t" + ESIndexHelper.getIndexOfWeek(prefix));
+        // 获取本周前两周的索引
+        System.out.println("获取本周前两周的索引：\t" + ESIndexHelper.getIndexOfWeek(prefix, -2));
+        // 输出2017年9月6日那周的索引
+        System.out.println("输出2017年9月6日那周的索引：(9.3)\t" + ESIndexHelper.getIndexOfWeek(prefix, time));
+        // 输出 2017年9月6日的后两周的索引索引
+        System.out.println("输出2017年9月6日当周的索引：(9.3)\t" + ESIndexHelper.getIndexOfWeekByMillis(prefix, timestamp));
+
+        // 获取本周的索引
+        System.out.println("获取本日的索引：\t" + ESIndexHelper.getIndexOfDay(prefix));
+        // 获取本周前两周的索引
+        System.out.println("获取本日前两天的索引：\t" + ESIndexHelper.getIndexOfDay(prefix, -2));
+        // 输出9月6日那周的索引
+        System.out.println("输出2017年9月6日那天的索引：\t" + ESIndexHelper.getIndexOfDay(prefix, time));
+        // 输出9月6日那周的索引
+        System.out.println("输出2017年9月6日当天的索引：\t" + ESIndexHelper.getIndexOfDayByMillis(prefix, timestamp));
+    }
+
+}

--- a/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/healthmanager/newlog/HMNewLogIndexMgr.java
+++ b/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/healthmanager/newlog/HMNewLogIndexMgr.java
@@ -21,37 +21,26 @@
 package com.creditease.uav.healthmanager.newlog;
 
 import java.io.IOException;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.creditease.agent.helpers.DateTimeHelper;
 import com.creditease.agent.spi.AbstractComponent;
 import com.creditease.uav.elasticsearch.client.ESClient;
+import com.creditease.uav.elasticsearch.index.ESIndexHelper;
 
 /**
- * 
  * HMNewLogIndexMgr description: 日志索引的管理
  * 
- * 日志的索引以应用类型区分，每个应用类型为一个日志索引（Index），应用类型就是appid
+ * 每天自动建立一个全局索引，命名为uav_applog_yyyy-MM-dd，type与日志文件名相关。
  * 
- * 每个应用类型下不同的日志文件，以Type区分
- * 
- * 每个应用类型的日志索引也是按一个自然周（7天）一次切分，即每周日，产生一个新的索引来保存所有新的日志
- * 
- * 实际从实时运维角度日志也是时效性高，对时间跨度范围查询要求不高，只有在统计的时候才需要
- * 
- * 便于对不同的应用类型进行日志清理的策略
- *
  */
 public class HMNewLogIndexMgr extends AbstractComponent {
 
-    private static final String AppLog = "applog_";
+    private static final String AppLog = "applog";
     /**
      * Strings longer than the ignore_above setting will not be indexed This option is also useful for protecting
-     * against Lucene’s term byte-length limit of 32766 The value for ignore_above is the character count, but Lucene 
-     * counts bytes. If you use UTF-8 text with many non-ASCII characters, you may want to set the limit to 32766 / 3 = 
+     * against Lucene’s term byte-length limit of 32766 The value for ignore_above is the character count, but Lucene
+     * counts bytes. If you use UTF-8 text with many non-ASCII characters, you may want to set the limit to 32766 / 3 =
      * 10922 since UTF-8 characters may occupy at most 3 bytes
      */
     private static final int IGNORE_ABOVE = 32766 / 3;
@@ -66,78 +55,35 @@ public class HMNewLogIndexMgr extends AbstractComponent {
     }
 
     /**
-     * 获取当前正在使用的索引名称AppLog_<appid>_<所属周的周日日期>
+     * 获取日期对应的索引
      * 
-     * 判断当前是属于那个周的索引，命名是以周日开头的那天日期，比如2017-06-25（周日）
-     * 
-     * 举例： 2017-06-24的数据实际是在2017-06-18（周日）的索引里面
-     * 
-     * @param appid
+     * @param date
+     *            yyyy-MM-dd
      * @return
      */
-    public String getIndexByDate(String date, String appid) {
+    public String getIndexByDate(String date) {
 
-        Date d = DateTimeHelper.convertToDate(date);
-
-        Calendar c = Calendar.getInstance();
-
-        c.setTime(d);
-
-        return this.getCurrentIndex(c, appid, 0);
+        return ESIndexHelper.getIndexOfDay(AppLog, date);
     }
 
     /**
-     * getCurrentIndex
+     * 获取当前的索引
      * 
-     * @param c
-     * @param appid
-     * @param when
      * @return
      */
-    private String getCurrentIndex(Calendar c, String appid, int when) {
+    public String getCurrentIndex() {
 
-        int dayOfWeek = c.get(Calendar.DAY_OF_WEEK) - 1;
-
-        Date d = DateTimeHelper.dateAdd(DateTimeHelper.INTERVAL_DAY, c.getTime(), -dayOfWeek);
-
-        if (when != 0) {
-            d = DateTimeHelper.dateAdd(DateTimeHelper.INTERVAL_WEEK, d, when);
-        }
-
-        return AppLog + formatAppid(appid) + "_" + DateTimeHelper.toFormat("yyyy-MM-dd", d.getTime());
-    }
-
-    /**
-     * 格式化一些不符合ES规范的字符
-     * 
-     * @param appid
-     * @return
-     */
-    private String formatAppid(String appid) {
-
-        return appid.toLowerCase().replace('.', '_');
-    }
-
-    /**
-     * getCurrentIndex
-     * 
-     * @param appid
-     * @return
-     */
-    public String getCurrentIndex(String appid) {
-
-        return this.getCurrentIndex(Calendar.getInstance(), appid, 0);
+        return ESIndexHelper.getIndexOfDay(AppLog);
     }
 
     /**
      * 准备索引，没有就创建
      * 
-     * @param appid
      * @return
      */
-    public String prepareIndex(String appid) {
+    public String prepareIndex() {
 
-        String currentIndex = getCurrentIndex(appid);
+        String currentIndex = getCurrentIndex();
 
         if (client.existIndex(currentIndex) == true) {
             return currentIndex;
@@ -150,8 +96,8 @@ public class HMNewLogIndexMgr extends AbstractComponent {
             }
 
             Map<String, String> set = new HashMap<String, String>();
-            set.put("index.number_of_shards", "2");
-            set.put("index.number_of_replicas", "0");
+            set.put("index.number_of_shards", "5");
+            set.put("index.number_of_replicas", "1");
 
             try {
                 client.creatIndex(currentIndex, null, set, null);
@@ -160,14 +106,12 @@ public class HMNewLogIndexMgr extends AbstractComponent {
                 log.err(this, "create ES Index FAIL: ", e);
             }
 
-            String sappid = formatAppid(appid);
-
             /**
              * 变更别名到当前新的Index
              */
-            String previousIndex = this.getCurrentIndex(Calendar.getInstance(), appid, -1);
-            client.addIndexAlias(currentIndex, AppLog + sappid);
-            client.removeIndexAlias(previousIndex, AppLog + sappid);
+            String previousIndex = this.getPreviousIndex();
+            client.addIndexAlias(currentIndex, AppLog);
+            client.removeIndexAlias(previousIndex, AppLog);
 
         }
 
@@ -177,12 +121,12 @@ public class HMNewLogIndexMgr extends AbstractComponent {
     /**
      * 检查type是否存在，如果不存在就创建Mapping
      * 
-     * @param appid
+     * @param index
      * @param type
      */
-    public void prepareIndexType(String appid, String type) {
+    public void prepareIndexType(String index, String type) {
 
-        boolean check = client.existType(appid, type);
+        boolean check = client.existType(index, type);
 
         if (check == true) {
             return;
@@ -190,45 +134,40 @@ public class HMNewLogIndexMgr extends AbstractComponent {
 
         synchronized (this) {
 
-            check = client.existType(appid, type);
+            check = client.existType(index, type);
 
             if (check == true) {
                 return;
             }
 
             Map<String, Map<String, Object>> mapping = new HashMap<>();
+            Map<String, Object> fields = new HashMap<>();
 
-            // 设置
-            Map<String, Object> sfields = new HashMap<>();
-
-            sfields.put("type", "keyword");
-            sfields.put("ignore_above", IGNORE_ABOVE);
-
-            mapping.put("ipport", sfields);
+            fields.put("type", "keyword");
+            mapping.put("ipport", fields);
+            mapping.put("appid", fields);
 
             // 设置分词器
             Map<String, Object> multiFields = new HashMap<>();
-
-            multiFields.put("type", "text");
-
             Map<String, Object> afields = new HashMap<>();
-
-            multiFields.put("fields", afields);
-
             Map<String, String> fmapping = new HashMap<>();
-
-            afields.put("chinese", fmapping);
+            Map<String, Object> sfields = new HashMap<>();
 
             fmapping.put("type", "text");
             fmapping.put("include_in_all", "true");
             fmapping.put("analyzer", "ik_max_word");
             fmapping.put("search_analyzer", "ik_max_word");
 
+            sfields.put("type", "keyword");
+            sfields.put("ignore_above", IGNORE_ABOVE);
+
             /**
              * field: astring, 可以按字符串匹配
              */
             afields.put("asstring", sfields);
-
+            afields.put("chinese", fmapping);
+            multiFields.put("fields", afields);
+            multiFields.put("type", "text");
             mapping.put("content", multiFields);
 
             /**
@@ -237,18 +176,29 @@ public class HMNewLogIndexMgr extends AbstractComponent {
             Map<String, Object> timestamp = new HashMap<>();
             Map<String, Object> timefields = new HashMap<>();
             Map<String, Object> longType = new HashMap<>();
-            mapping.put("l_timestamp", timestamp);
-            timestamp.put("type", "date");
-            timestamp.put("fields", timefields);
-            timefields.put("long", longType);
+
             longType.put("type", "long");
+            timefields.put("long", longType);
+            timestamp.put("fields", timefields);
+            timestamp.put("type", "date");
+            mapping.put("l_timestamp", timestamp);
 
             try {
-                client.setIndexTypeMapping(appid, type.toLowerCase(), mapping);
+                client.setIndexTypeMapping(index, type.toLowerCase(), mapping);
             }
             catch (IOException e) {
                 log.err(this, "Set ES Index Type Mapping FAIL: ", e);
             }
         }
+    }
+
+    /**
+     * 获取前一天的索引
+     * 
+     * @return
+     */
+    private String getPreviousIndex() {
+
+        return ESIndexHelper.getIndexOfDay(AppLog, -1);
     }
 }

--- a/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/healthmanager/newlog/handlers/NewLogDataMessageHandler.java
+++ b/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/healthmanager/newlog/handlers/NewLogDataMessageHandler.java
@@ -66,7 +66,7 @@ public class NewLogDataMessageHandler implements MessageHandler {
     }
 
     /**
-     * [ { time:1464248773620, host:"09-201211070016", ip:"127.0.0.1",
+     * [ { time:1464248773620, host:"09-201211070016", ip:"10.10.37.32",
      * svrid:"F:/testenv/apache-tomcat-7.0.65---F:/testenv/apache-tomcat-7.0.65", tag:"L", frames:{ "ccsp":[ {
      * "MEId":"log", "Instances":[ { "id":"F:/testenv/apache-tomcat-7.0.65/logs/ccsp.log", "values":{ "content":[ {
      * "content":"2016-localhost-startStop-1INFORootWebApplicationContext:initializationstarted",
@@ -221,7 +221,7 @@ public class NewLogDataMessageHandler implements MessageHandler {
             String uuid = EncodeHelper.encodeMD5(uuidStr.toString());
 
             // 准备index，如果不存在，就创建
-            String currentIndex = indexMgr.prepareIndex(appid);
+            String currentIndex = indexMgr.prepareIndex();
 
             // 检查type是否存在，不存在就创建
             indexMgr.prepareIndexType(currentIndex, logFileType.toLowerCase());
@@ -231,6 +231,7 @@ public class NewLogDataMessageHandler implements MessageHandler {
             /**
              * 用于区分不同机器上的应用实例
              */
+            line.put("appid", appid);
             line.put("ipport", ipport);
 
             irb.setSource(line);

--- a/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/healthmanager/newlog/handlers/NewLogDataMessageHandler.java
+++ b/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/healthmanager/newlog/handlers/NewLogDataMessageHandler.java
@@ -66,7 +66,7 @@ public class NewLogDataMessageHandler implements MessageHandler {
     }
 
     /**
-     * [ { time:1464248773620, host:"09-201211070016", ip:"10.10.37.32",
+     * [ { time:1464248773620, host:"09-201211070016", ip:"127.0.0.1",
      * svrid:"F:/testenv/apache-tomcat-7.0.65---F:/testenv/apache-tomcat-7.0.65", tag:"L", frames:{ "ccsp":[ {
      * "MEId":"log", "Instances":[ { "id":"F:/testenv/apache-tomcat-7.0.65/logs/ccsp.log", "values":{ "content":[ {
      * "content":"2016-localhost-startStop-1INFORootWebApplicationContext:initializationstarted",

--- a/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/healthmanager/newlog/http/NewLogQueryHandler.java
+++ b/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/healthmanager/newlog/http/NewLogQueryHandler.java
@@ -121,11 +121,12 @@ public class NewLogQueryHandler extends AbstractHttpHandler<UAVHttpMessage> {
             queryBuilder.must(QueryBuilders.rangeQuery("l_num").lt(endLine));
         }
 
-        /**
-         * 关键字ipport
-         */
-        String ipport = data.getRequest("ipport");
+        String appid = data.getRequest("appid");
+        if (appid != null) {
+            queryBuilder.must(QueryBuilders.termQuery("appid", appid));
+        }
 
+        String ipport = data.getRequest("ipport");
         if (ipport != null) {
             queryBuilder.must(QueryBuilders.termQuery("ipport", ipport));
         }
@@ -306,17 +307,15 @@ public class NewLogQueryHandler extends AbstractHttpHandler<UAVHttpMessage> {
     private SearchResponse query(UAVHttpMessage data, QueryBuilder queryBuilder, QueryBuilder postFilter,
             SortBuilder[] sorts) {
 
-        String appid = data.getRequest("appid");
-
         String indexDate = data.getRequest("indexdate");
         String currentIndex;
         if (indexDate != null) {
             // 获得指定的index
-            currentIndex = this.indexMgr.getIndexByDate(indexDate, appid);
+            currentIndex = this.indexMgr.getIndexByDate(indexDate);
         }
         else {
             // get current index
-            currentIndex = this.indexMgr.getCurrentIndex(appid);
+            currentIndex = this.indexMgr.getCurrentIndex();
         }
 
         // get logtype for search

--- a/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/invokechain/collect/SlowOperDataCollectHandler.java
+++ b/com.creditease.uav.invokechain/src/main/java/com/creditease/uav/invokechain/collect/SlowOperDataCollectHandler.java
@@ -158,7 +158,7 @@ public class SlowOperDataCollectHandler extends AbstractCollectDataHandler {
         /**
          * 获取当前正在使用的index名称
          */
-        String currentIndex = indexMgr.prepareIndex(span.getAppid());
+        String currentIndex = indexMgr.prepareIndex();
         /**
          * 准备对应type
          */


### PR DESCRIPTION
1.日志、调用链、重调用链、线程分析分别用一个索引，由按周改为按天滚动。
2.日志索引的分片由2改为5，所有索引(日志、APM)的副本由0改为1。
3.索引改为按天滚动后之前24小时内的查询涉及两个索引，故改为当天查询。
4.日志、重调用链原索引与appid有关，修改后插入和查询时增加appid，且appid的type设为keyword
具体索引修改如下：
1）日志
原索引：applog_appid_yyyy-MM-dd，现索引：uav_applog_yyyy-MM-dd
原索引与appid有关，查询时使用appid和type，为区分不同应用，插入和查询ES时增加appid，且appid的type设为keyword
2）调用链
原索引：uav_ivc_db_yyyy-MM-dd，现索引：uav_ivc_yyyy-MM-dd
查询使用appuuid
3）重调用链
原索引：ivcdat_appid_yyyy-MM-dd，现索引：uav_ivcdat_yyyy-MM-dd
原索引与appid相关，查询使用appid和tranceid，重调用链数据中已经包含appid，故appid设为keyword
4）线程分析
原索引：uav_jta_db_yyyy-MM-dd，现索引：uav_jta_yyyy-MM-dd